### PR TITLE
Make regions next to sea streets more interesting

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -116,9 +116,9 @@ The following points on the map can be crossed both by land-land and sea-sea mov
 
 * **Denmark islands**
 * **Gibraltar**
-* **Istanbul:** Notes:
-    * Land-land crossing is irrelevant since it's the same region
-    * Can only be crossed by sea if friendly power owns region
+* **Istanbul:**
+
+Sea-sea movement is not possible if both land regions at the crossing are controlled by an enemy power.
 
 ## Battles
 When a move proceeds into an enemy region, the move ends and a battle is initiated with all moved


### PR DESCRIPTION
Make regions next to sea streets more interesting
Make the rules consistent on these places. Also deal with the fact that you probably can pass through the street if the region is controlled by no-one (something which was wrong in the rules)

Historic references:
https://en.wikipedia.org/wiki/Military_history_of_Gibraltar_during_World_War_II
https://en.wikipedia.org/wiki/Battle_of_the_Denmark_Strait
This is also a correct reflection of what happened in WWII
