### PR TITLE
Moved Sweden's star to Denmark.

### DIFF
--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -1,3 +1,5 @@
 # Changes to the map
 
 *Note: These are changes to the map as it was on 2016-09-24 that are not captured in the rules.
+
+* Moved Sweden's star to Denmark.

--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -3,3 +3,5 @@
 *Note: These are changes to the map as it was on 2016-09-24 that are not captured in the rules.
 
 * Moved Sweden's star to Denmark.
+* Denmark's coin coint changes from 2 to 5
+* Sweden's coin coint changes from 6 to 3


### PR DESCRIPTION
Having the star in Stockholm makes it too easy for UK and Russia to take and keep it. Moving it closer to Germany balances this a bit more.
