### PR TITLE
Split UK in England and Scotland

### DIFF
--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -1,3 +1,5 @@
 # Changes to the map
 
 *Note: These are changes to the map as it was on 2016-09-24 that are not captured in the rules.
+
+* Split UK (star, 5 coins) in England (star, 3 coins) and Scotland (2 coins).

--- a/Rules.md
+++ b/Rules.md
@@ -179,7 +179,8 @@ decision.
 
 # Special abilities of players
 * **UK**: Owns the seas
-    * UK units get 3 MP from the move token if the move starts in the UK or Ireland region
+    * UK units get 3 MP from the move token if the move starts in the England, Scotland or Ireland
+      region
 * **Germany**: Autobahn
     * German units get 3 MP from the move token if the regions touched by the move except for the
       last are German.
@@ -203,8 +204,8 @@ decision.
 
 **Troops**
 * **UK**
-    * 2 infantry in UK
-    * 1 infantry in Ireland
+    * 2 infantry in England
+    * 1 infantry in Scotland
 * **Germany**
     * 2 infantry in E-Germany
     * 1 infantry in W-Germany


### PR DESCRIPTION
This makes UK + Ireland 1 coin less lucrative (1 extra unit needed) and slows down UK buildup.
