### PR TITLE
Benelux's coin count changes from 6 to 5

### DIFF
--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -1,3 +1,5 @@
 # Changes to the map
 
 *Note: These are changes to the map as it was on 2016-09-24 that are not captured in the rules.
+
+* Benelux's coin coint changes from 6 to 5


### PR DESCRIPTION
Benelux can be quite well defended if occupied by France, in which case 6 coins may be a bit too much.
