### PR TITLE
Reduced max number of artilleries

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -33,7 +33,7 @@
 * **Per player:**
     * Units:
         * Infantry: 14
-        * Artillery: 6
+        * Artillery: 5
     * Command tokens:
         * Invest: 2
         * Dig trench: 1


### PR DESCRIPTION
I created 14 infantries and 6 artilleries and every player needs to put one unit on the strategic region counter (which really helped counting a lot in test game 4!).

I think sacrificing an artillery piece makes most sense, since they will cost 2 soon.

You could argue I should make new pieces, but I'm not convinced that 5 artilleries is not enough.