### PR TITLE
Randomized board initialisation

### DIFF
--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -13,3 +13,7 @@
 * Add "North Atlantic Ocean" between Atlantic Ocean and North Sea, bordering Ireland and Scotland.
 * Indiciate sea crossings on map to make it clear that the Istambul crossing is between Turkey and
   Greece
+
+## Changes from v1.2 to v1.3
+* Caucasus's coin count increses from 1 to 2
+* Yugoslavia's coin count increses from 1 to 2

--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -15,6 +15,9 @@
   Greece
 
 ## Changes from v1.2 to v1.3
+* England's coin count increases from 3 to 4
+
+## Changes from v1.3 to v1.4
 * Caucasus's coin count increses from 1 to 2
 * Yugoslavia's coin count increses from 1 to 2
-* England's coin count increases from 3 to 4
+* Moved Denmark's star to Sweden.

--- a/Map_changelog.md
+++ b/Map_changelog.md
@@ -20,4 +20,3 @@
 ## Changes from v1.3 to v1.4
 * Caucasus's coin count increses from 1 to 2
 * Yugoslavia's coin count increses from 1 to 2
-* Moved Denmark's star to Sweden.

--- a/Rules.md
+++ b/Rules.md
@@ -266,7 +266,7 @@ Same setup as  6 players, except without Austro-Hungarian Empire and:
   </tr>
   <tr>
     <td>Austria</td>
-    <td>3</td>
+    <td>2</td>
     <td>3</td>
     <td>with border W-Germany</td>
   </tr>
@@ -283,13 +283,13 @@ Same setup as 6 players, except without Austro-Hungarian Empire and France and:
   </tr>
   <tr>
     <td>Austria</td>
-    <td>3</td>
+    <td>2</td>
     <td>3</td>
     <td>with border W-Germany</td>
   </tr>
   <tr>
     <td>N-France</td>
-    <td>3</td>
+    <td>2</td>
     <td>3</td>
     <td>
       with border W-Germany<br>

--- a/Rules.md
+++ b/Rules.md
@@ -217,7 +217,7 @@ decision.
 **Trenches:**
 * Between N-France and W-Germany on both sides
 
-**Troops**
+**Troops:**
 * **UK**
     * 2 infantry in England
     * 1 infantry in Scotland
@@ -237,18 +237,39 @@ decision.
     * 2 infantry in Austria
     * 1 infantry in Hungary
 
+**Initial seeding:**
+
+For every unoccupied region, roll a dice. If its result is:
+* 1-2: Nothing happens
+* 3-4: Add 1 coin
+* 5-6: Add 2 coins + neutral infantry
+
 ## 5 players
 Note: This game has to be played with the uncertain allegiance extension, except only for the allied
 players and with half the USA reinforcements.
 
-Same setup as  6 players, except:
-
-**Troops and other trenches:**
-* **Austro-Hungarian Empire** (neutral):
+Same setup as  6 players, except without Austro-Hungarian Empire and:
 <table>
   <tr>
     <th>Region</th>
-    <th>Infantry</th>
+    <th>Neutral infantry</th>
+    <th>Coins</th>
+    <th>Trenches</th>
+  </tr>
+  <tr>
+    <td>Austria</td>
+    <td>3</td>
+    <td>3</td>
+    <td>with border W-Germany</td>
+  </tr>
+</table>
+
+## 4 players
+Same setup as 6 players, except without Austro-Hungarian Empire and France and:
+<table>
+  <tr>
+    <th>Region</th>
+    <th>Neutral infantry</th>
     <th>Coins</th>
     <th>Trenches</th>
   </tr>
@@ -259,72 +280,22 @@ Same setup as  6 players, except:
     <td>with border W-Germany</td>
   </tr>
   <tr>
-    <td>Hungary</td>
-    <td>3</td>
-    <td>3</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Romania</td>
-    <td>4</td>
-    <td>3</td>
-    <td>with border Ukraine</td>
-  </tr>
-  <tr>
-    <td>Yugoslavia</td>
-    <td>1</td>
-    <td>1</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Bulgaria</td>
-    <td>4</td>
-    <td>3</td>
-    <td>with border Turkey</td>
-  </tr>
-</table>
-
-## 4 players
-Same setup as  5 players, except:
-
-**Troops and other trenches:**
-* **France** (neutral):
-<table>
-  <tr>
-    <th>Region</th>
-    <th>Infantry</th>
-    <th>Coins</th>
-    <th>Trenches</th>
-  </tr>
-  <tr>
     <td>N-France</td>
-    <td>4</td>
-    <td>4</td>
+    <td>3</td>
+    <td>3</td>
     <td>
       with border W-Germany<br>
       with border England
     </td>
   </tr>
   <tr>
-    <td>S-France</td>
-    <td>3</td>
-    <td>3</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Spain</td>
-    <td>3</td>
-    <td>3</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Portugal</td>
+    <td>Italy</td>
     <td>2</td>
     <td>2</td>
     <td></td>
   </tr>
   <tr>
-    <td>Morocco</td>
+    <td>N-Africa</td>
     <td>2</td>
     <td>2</td>
     <td></td>


### PR DESCRIPTION
Increased maximal coin count of Caucasus and Yugoslavia to make all regions have minimally 2 coins. This avoids the initialisation edge case.