### PR TITLE
Reduced amount of starting coins of neutral territories to amount of neutral units

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -69,19 +69,19 @@
   <tr>
     <td>N-France</td>
     <td>2</td>
-    <td>3</td>
+    <td>2</td>
     <td>with border W-Germany</td>
   </tr>
   <tr>
     <td>Austria</td>
     <td>2</td>
-    <td>3</td>
+    <td>2</td>
     <td></td>
   </tr>
   <tr>
     <td>Poland</td>
     <td>1</td>
-    <td>2</td>
+    <td>1</td>
     <td></td>
   </tr>
   <tr>
@@ -133,7 +133,7 @@
   <tr>
     <td>Benelux</td>
     <td>1</td>
-    <td>2</td>
+    <td>1</td>
     <td></td>
   </tr>
   <tr>
@@ -151,19 +151,19 @@
   <tr>
     <td>Austria</td>
     <td>1</td>
-    <td>2</td>
+    <td>1</td>
     <td></td>
   </tr>
   <tr>
     <td>Poland</td>
     <td>1</td>
-    <td>2</td>
+    <td>1</td>
     <td></td>
   </tr>
   <tr>
     <td>Italy</td>
     <td>1</td>
-    <td>2</td>
+    <td>1</td>
     <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
As per "Alliances test game v1.10":
https://docs.google.com/document/d/1FDDip981W9kPMO0xDeM4DOfS6hJWEXGBXRyPwadnJlg/edit#

After merging, all neutral territories have the same amount of coins and units in all scenarios.