### PR TITLE
Remove redundant and false information about coins in regions

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -264,7 +264,6 @@ Choose a [scenario](Scenarios.md) for the desired number of players *at random* 
 
 ## Coins
 
-* Every player gets 2 coins in every region they own
 * Every player gets 3 coins in their supply
 
 # First play


### PR DESCRIPTION
False because of beginner scenario (regions can start with 1 coin) and redundant because every scenario specifies the starting coins.