### PR TITLE
Change empire order so all scenarios interleave 2 teams

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -41,13 +41,13 @@
 There are 2 opposing teams:
 
 * The Triple Entente:
-    * The British Empire
     * The Russian Empire (Россійская Имперія)
     * The French Third Republic (La Troisième République)
+    * The British Empire
 * The Central Powers:
     * The German Empire (Das Deutsches Kaiserreich)
-    * The Ottoman Empire (دولت عليه عثمانیه)
     * The Austro-Hungarian Empire (Die Österreichisch-Ungarische Monarchie / Az Osztrák–Magyar Monarchia)
+    * The Ottoman Empire (دولت عليه عثمانیه)
 
 # Goal of the game
 
@@ -73,18 +73,18 @@ brackets ([example]) need no player input and can be done quickly.
 
        The number-player correspondence is indicated on the board:
 
-        * 1 - British Empire (down)
+        * 1 - Russian Empire (down)
         * 2 - German Empire (up)
-        * 3 - Russian Empire (down)
-        * 4 - Ottoman Empire (up)
-        * 5 - French Republic (down)
-        * 6 - Austro-Hungarian Empire (up)
+        * 3 - French Republic (down)
+        * 4 - Austro-Hungarian Empire (up)
+        * 5 - British Empire (down)
+        * 6 - Ottoman Empire (up)
 
        The board also indicates the direction of the player order. Note that the full circle of the
        player order should always be the same as that of the above player order.
 
-       *Example: If the dice shows 4 eyes, the player order is Ottoman Empire, Russian Empire, German
-       Empire, British Empire, Austro-Hungarian Empire, French Republic.*
+       *Example: If the dice shows 4 eyes, the player order is Austro-Hungarian Empire, French
+       Republic, German Empire, Russian Empire, Ottoman Empire, British Empire.*
 1. **Resolve Invest and Dig trenches tokens** (\*)
 1. **Resolve Move tokens** (in player order)
 1. **Production, payment and mutiny** (\*)

--- a/Scenarios.md
+++ b/Scenarios.md
@@ -4,10 +4,6 @@
 
 ### Players, their units and their coins
 
-* **British Empire**
-    * 1 infantry in England + 2 coins
-    * 1 infantry in Scotland + 2 coins
-    * 1 infantry in The Atlantic Ocean
 * **Russian Empire**
     * 1 infantry in Russia + 2 coins
     * 1 infantry in Ukraine + 1 coin
@@ -16,18 +12,22 @@
     * 1 infantry in N-France + 2 coins
     * 1 infantry in S-France + 1 coin
     * 1 infantry in Spain + 1 coin
+* **British Empire**
+    * 1 infantry in England + 2 coins
+    * 1 infantry in Scotland + 2 coins
+    * 1 infantry in The Atlantic Ocean
 * **German Empire**
     * 1 infantry in E-Germany + 2 coins
     * 1 infantry in W-Germany + 1 coin
     * 1 infantry in Denmark + 1 coin
-* **Ottoman Empire**
-    * 1 infantry in Turkey + 2 coins
-    * 1 infantry in Middle East + 2 coins
-    * 1 infantry in The Mediterranean Sea
 * **Austro-Hungarian Empire**
     * 1 infantry in Austria + 2 coins
     * 1 infantry in Hungary + 1 coin
     * 1 infantry in Bosnia + 1 coin
+* **Ottoman Empire**
+    * 1 infantry in Turkey + 2 coins
+    * 1 infantry in Middle East + 2 coins
+    * 1 infantry in The Mediterranean Sea
 
 When done, every player should have 3 infantry units that occupy 3 regions containing a total of 4
 coins.
@@ -89,24 +89,24 @@ coins.
 
 ### Players and their units
 
-* **British Empire**
-    * 2 infantry in England
-    * 2 infantry in Scotland
 * **Russian Empire**
     * 2 infantry in Russia
     * 2 infantry in Ukraine
 * **French Republic**
     * 2 infantry in N-France
     * 2 infantry in S-France
+* **British Empire**
+    * 2 infantry in England
+    * 2 infantry in Scotland
 * **German Empire**
     * 2 infantry in E-Germany
     * 2 infantry in W-Germany
-* **Ottoman Empire**
-    * 2 infantry in Turkey
-    * 2 infantry in Middle East
 * **Austro-Hungarian Empire**
     * 2 infantry in Austria
     * 2 infantry in Hungary
+* **Ottoman Empire**
+    * 2 infantry in Turkey
+    * 2 infantry in Middle East
 
 ### Coins
 
@@ -133,24 +133,24 @@ Every player gets 2 coins in every region they own.
 
 ### Players and their units
 
-* **British Empire**
-    * 2 infantry in England
-    * 2 infantry in Scotland
 * **Russian Empire**
     * 2 infantry in Russia
     * 2 infantry in Ukraine
 * **French Republic**
     * 2 infantry in N-France
     * 2 infantry in S-France
+* **British Empire**
+    * 2 infantry in England
+    * 2 infantry in Scotland
 * **German Empire**
     * 2 infantry in E-Germany
     * 2 infantry in W-Germany
-* **Ottoman Empire**
-    * 2 infantry in Turkey
-    * 2 infantry in Middle East
 * **Austro-Hungarian Empire**
     * 2 infantry in Austria
     * 2 infantry in Hungary
+* **Ottoman Empire**
+    * 2 infantry in Turkey
+    * 2 infantry in Middle East
 
 ### Coins
 
@@ -302,12 +302,12 @@ coins.
 
 ### Players and their units
 
-* **British Empire**
-    * 2 infantry in England
-    * 2 infantry in Scotland
 * **Russian Empire**
     * 2 infantry in Russia
     * 2 infantry in Ukraine
+* **British Empire**
+    * 2 infantry in England
+    * 2 infantry in Scotland
 * **German Empire**
     * 2 infantry in E-Germany
     * 2 infantry in W-Germany


### PR DESCRIPTION
And also, our primary 4-player scenario (beginner and C) empires are placed at the top of the list and thus at dice rolls 1-4.